### PR TITLE
Add basic support for dsk images

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -89,5 +89,6 @@ exports.supportedFileTypes = [
   { extension: 'bz2' , type: 'compressed' },
   { extension: 'xz'  , type: 'compressed' },
   { extension: 'img' , type: 'image'      },
-  { extension: 'iso' , type: 'image'      }
+  { extension: 'iso' , type: 'image'      },
+  { extension: 'dsk' , type: 'image'      }
 ];


### PR DESCRIPTION
This format is used by the Ostro Project
(https://github.com/ostroproject/ostro-os), and its basically an raw
image (`.img`) that can be optionally flashed with `bmaptools` to
improve the writing speed.

`bmaptools` support is something we want to deal in the near future, but
at least for now, we add basic support for `.dsk` files as if they were
normal `.img` files.

See: https://github.com/resin-io/etcher/issues/491
Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>