### PR TITLE
Add `hddimg` to the supported file types array

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -84,11 +84,12 @@ exports.getFromFilePath = function(file) {
  * });
  */
 exports.supportedFileTypes = [
-  { extension: 'zip' , type: 'archive' },
-  { extension: 'gz'  , type: 'compressed' },
-  { extension: 'bz2' , type: 'compressed' },
-  { extension: 'xz'  , type: 'compressed' },
-  { extension: 'img' , type: 'image'      },
-  { extension: 'iso' , type: 'image'      },
-  { extension: 'dsk' , type: 'image'      }
+  { extension: 'zip'    , type: 'archive' },
+  { extension: 'gz'     , type: 'compressed' },
+  { extension: 'bz2'    , type: 'compressed' },
+  { extension: 'xz'     , type: 'compressed' },
+  { extension: 'img'    , type: 'image'      },
+  { extension: 'iso'    , type: 'image'      },
+  { extension: 'dsk'    , type: 'image'      },
+  { extension: 'hddimg' , type: 'image'      }
 ];


### PR DESCRIPTION
This format is generated by the Yocto project, and its basically another
name for raw images.

See: https://github.com/resin-io/etcher/issues/549
Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>