### PR TITLE
Support a `url` property in `_info/manifest.json`

### DIFF
--- a/lib/archive.js
+++ b/lib/archive.js
@@ -105,6 +105,7 @@ exports.extractImage = (archive, hooks) => {
       stream: results.imageStream,
       size: imageEntry.size,
       name: results.manifest.name,
+      url: results.manifest.url,
       transform: new PassThroughStream()
     };
   });

--- a/tests/metadata/zip.spec.js
+++ b/tests/metadata/zip.spec.js
@@ -38,9 +38,9 @@ describe('EtcherImageStream: Metadata ZIP', function() {
 
   });
 
-  describe('given an archive with a `manifest.json` containing a name', function() {
+  describe('given an archive with a `manifest.json`', function() {
 
-    const archive = path.join(ZIP_PATH, 'rpi-with-name.zip');
+    const archive = path.join(ZIP_PATH, 'rpi-with-manifest.zip');
 
     tester.extractFromFilePath(
       archive,
@@ -49,6 +49,13 @@ describe('EtcherImageStream: Metadata ZIP', function() {
     it('should read the manifest name property', function(done) {
       imageStream.getFromFilePath(archive).then((image) => {
         m.chai.expect(image.name).to.equal('Raspberry Pi');
+        done();
+      });
+    });
+
+    it('should read the manifest url property', function(done) {
+      imageStream.getFromFilePath(archive).then((image) => {
+        m.chai.expect(image.url).to.equal('https://www.raspberrypi.org');
         done();
       });
     });


### PR DESCRIPTION
See: https://github.com/resin-io/etcher/issues/470
Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>