### PR TITLE
Report uncompressed size for xz compressed images

### DIFF
--- a/lib/handlers.js
+++ b/lib/handlers.js
@@ -19,7 +19,7 @@
 const Bluebird = require('bluebird');
 const fs = Bluebird.promisifyAll(require('fs'));
 const PassThroughStream = require('stream').PassThrough;
-const lzma = require('lzma-native');
+const lzma = Bluebird.promisifyAll(require('lzma-native'));
 const zlib = require('zlib');
 const unbzip2Stream = require('unbzip2-stream');
 const archive = require('./archive');
@@ -79,10 +79,17 @@ module.exports = {
    * @returns {Promise}
    */
   'application/x-xz': function(file) {
-    return Bluebird.props({
-      stream: fs.createReadStream(file),
-      size: fs.statAsync(file).get('size'),
-      transform: Bluebird.resolve(lzma.createDecompressor())
+    return fs.openAsync(file, 'r').then((fileDescriptor) => {
+      return lzma.parseFileIndexFDAsync(fileDescriptor).tap(() => {
+        return fs.closeAsync(fileDescriptor);
+      });
+    }).then((metadata) => {
+      return {
+        stream: fs.createReadStream(file)
+          .pipe(lzma.createDecompressor()),
+        size: metadata.uncompressedSize,
+        transform: new PassThroughStream()
+      };
     });
   },
 


### PR DESCRIPTION
This greatly simplifies checking that the uncompressed image still fits in the
selected drive in Etcher.

Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>