### PR TITLE
Implement `.getEstimatedFinalSize()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Documentation
 * [imageStream](#module_imageStream)
     * [.supportedFileTypes](#module_imageStream.supportedFileTypes) : <code>Array.&lt;String&gt;</code>
     * [.getFromFilePath(file)](#module_imageStream.getFromFilePath) ⇒ <code>Promise</code>
+    * [.getEstimatedFinalSize(file)](#module_imageStream.getEstimatedFinalSize) ⇒ <code>Promise</code>
 
 <a name="module_imageStream.supportedFileTypes"></a>
 
@@ -75,6 +76,33 @@ imageStream.getFromFilePath('path/to/rpi.img.xz').then(function(image) {
   image.stream
     .pipe(image.transform)
     .pipe(fs.createWriteStream('/dev/disk2'));
+});
+```
+<a name="module_imageStream.getEstimatedFinalSize"></a>
+
+### imageStream.getEstimatedFinalSize(file) ⇒ <code>Promise</code>
+This function is useful to determine the final size of an image
+after decompression or any other needed transformation.
+
+**NOTE:** This function is known to output incorrect results for
+`bzip2`. For this compression format, this function will simply
+return the size of the compressed file.
+
+**Kind**: static method of <code>[imageStream](#module_imageStream)</code>  
+**Summary**: Get the estimated final size from image  
+**Access:** public  
+**Fulfil**: <code>Number</code> - estimated final size  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| file | <code>String</code> | file path |
+
+**Example**  
+```js
+const imageStream = require('etcher-image-stream');
+
+imageStream.getEstimatedFinalSize('path/to/rpi.img.xz').then(function(estimatedSize) {
+  console.log(`The estimated final size is: ${estimatedSize}`);
 });
 ```
 

--- a/lib/handlers.js
+++ b/lib/handlers.js
@@ -22,6 +22,7 @@ const PassThroughStream = require('stream').PassThrough;
 const lzma = Bluebird.promisifyAll(require('lzma-native'));
 const zlib = require('zlib');
 const unbzip2Stream = require('unbzip2-stream');
+const gzipUncompressedSize = Bluebird.promisifyAll(require('gzip-uncompressed-size'));
 const archive = require('./archive');
 const zipArchiveHooks = require('./archive-hooks/zip');
 
@@ -64,6 +65,7 @@ module.exports = {
     return Bluebird.props({
       stream: fs.createReadStream(file),
       size: fs.statAsync(file).get('size'),
+      estimatedUncompressedSize: gzipUncompressedSize.fromFileAsync(file),
       transform: Bluebird.resolve(zlib.createGunzip())
     });
   },

--- a/lib/index.js
+++ b/lib/index.js
@@ -73,6 +73,36 @@ exports.getFromFilePath = function(file) {
 };
 
 /**
+ * @summary Get the estimated final size from image
+ * @function
+ * @public
+ *
+ * @description
+ * This function is useful to determine the final size of an image
+ * after decompression or any other needed transformation.
+ *
+ * **NOTE:** This function is known to output incorrect results for
+ * `bzip2`. For this compression format, this function will simply
+ * return the size of the compressed file.
+ *
+ * @param {String} file - file path
+ * @fulfil {Number} - estimated final size
+ * @returns {Promise}
+ *
+ * @example
+ * const imageStream = require('etcher-image-stream');
+ *
+ * imageStream.getEstimatedFinalSize('path/to/rpi.img.xz').then(function(estimatedSize) {
+ *   console.log(`The estimated final size is: ${estimatedSize}`);
+ * });
+ */
+exports.getEstimatedFinalSize = function(file) {
+  return exports.getFromFilePath(file).then(function(image) {
+    return image.estimatedUncompressedSize || image.size;
+  });
+};
+
+/**
  * @summary Supported file types
  * @type {String[]}
  * @public

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "adm-zip": "^0.4.7",
     "archive-type": "^3.2.0",
     "bluebird": "^3.3.5",
+    "gzip-uncompressed-size": "^1.0.0",
     "lodash": "^4.11.1",
     "lzma-native": "^1.1.0",
     "read-chunk": "^2.0.0",

--- a/tests/bz2.spec.js
+++ b/tests/bz2.spec.js
@@ -16,20 +16,41 @@
 
 'use strict';
 
+const m = require('mochainon');
+const fs = require('fs');
 const path = require('path');
 const DATA_PATH = path.join(__dirname, 'data');
 const IMAGES_PATH = path.join(DATA_PATH, 'images');
 const BZ2_PATH = path.join(DATA_PATH, 'bz2');
+const imageStream = require('../lib/index');
 const tester = require('./tester');
 
 describe('EtcherImageStream: BZ2', function() {
 
   this.timeout(10000);
 
-  describe('given a bz2 image', function() {
-    tester.extractFromFilePath(
-      path.join(BZ2_PATH, 'raspberrypi.img.bz2'),
-      path.join(IMAGES_PATH, 'raspberrypi.img'));
+  describe('.getFromFilePath()', function() {
+
+    describe('given a bz2 image', function() {
+      tester.extractFromFilePath(
+        path.join(BZ2_PATH, 'raspberrypi.img.bz2'),
+        path.join(IMAGES_PATH, 'raspberrypi.img'));
+    });
+
+  });
+
+  describe('.getEstimatedFinalSize()', function() {
+
+    it('should return the compressed size', function(done) {
+      const image = path.join(BZ2_PATH, 'raspberrypi.img.bz2');
+      const expectedSize = fs.statSync(image).size;
+
+      imageStream.getEstimatedFinalSize(image).then((estimatedSize) => {
+        m.chai.expect(estimatedSize).to.equal(expectedSize);
+        done();
+      });
+    });
+
   });
 
 });

--- a/tests/gz.spec.js
+++ b/tests/gz.spec.js
@@ -16,20 +16,41 @@
 
 'use strict';
 
+const m = require('mochainon');
+const fs = require('fs');
 const path = require('path');
 const DATA_PATH = path.join(__dirname, 'data');
 const IMAGES_PATH = path.join(DATA_PATH, 'images');
 const GZ_PATH = path.join(DATA_PATH, 'gz');
+const imageStream = require('../lib/index');
 const tester = require('./tester');
 
 describe('EtcherImageStream: GZ', function() {
 
   this.timeout(10000);
 
-  describe('given a gz image', function() {
-    tester.extractFromFilePath(
-      path.join(GZ_PATH, 'raspberrypi.img.gz'),
-      path.join(IMAGES_PATH, 'raspberrypi.img'));
+  describe('.getFromFilePath()', function() {
+
+    describe('given a gz image', function() {
+      tester.extractFromFilePath(
+        path.join(GZ_PATH, 'raspberrypi.img.gz'),
+        path.join(IMAGES_PATH, 'raspberrypi.img'));
+    });
+
+  });
+
+  describe('.getEstimatedFinalSize()', function() {
+
+    it('should return the correct estimated uncompressed size', function(done) {
+      const image = path.join(GZ_PATH, 'raspberrypi.img.gz');
+      const expectedSize = fs.statSync(path.join(IMAGES_PATH, 'raspberrypi.img')).size;
+
+      imageStream.getEstimatedFinalSize(image).then((estimatedSize) => {
+        m.chai.expect(estimatedSize).to.equal(expectedSize);
+        done();
+      });
+    });
+
   });
 
 });

--- a/tests/img.spec.js
+++ b/tests/img.spec.js
@@ -16,19 +16,40 @@
 
 'use strict';
 
+const m = require('mochainon');
+const fs = require('fs');
 const path = require('path');
 const DATA_PATH = path.join(__dirname, 'data');
 const IMAGES_PATH = path.join(DATA_PATH, 'images');
+const imageStream = require('../lib/index');
 const tester = require('./tester');
 
 describe('EtcherImageStream: IMG', function() {
 
   this.timeout(10000);
 
-  describe('given an img image', function() {
-    tester.extractFromFilePath(
-      path.join(IMAGES_PATH, 'raspberrypi.img'),
-      path.join(IMAGES_PATH, 'raspberrypi.img'));
+  describe('.getFromFilePath()', function() {
+
+    describe('given an img image', function() {
+      tester.extractFromFilePath(
+        path.join(IMAGES_PATH, 'raspberrypi.img'),
+        path.join(IMAGES_PATH, 'raspberrypi.img'));
+    });
+
+  });
+
+  describe('.getEstimatedFinalSize()', function() {
+
+    it('should return the file size', function(done) {
+      const image = path.join(IMAGES_PATH, 'raspberrypi.img');
+      const expectedSize = fs.statSync(image).size;
+
+      imageStream.getEstimatedFinalSize(image).then((estimatedSize) => {
+        m.chai.expect(estimatedSize).to.equal(expectedSize);
+        done();
+      });
+    });
+
   });
 
 });

--- a/tests/xz.spec.js
+++ b/tests/xz.spec.js
@@ -16,20 +16,41 @@
 
 'use strict';
 
+const m = require('mochainon');
+const fs = require('fs');
 const path = require('path');
 const DATA_PATH = path.join(__dirname, 'data');
 const IMAGES_PATH = path.join(DATA_PATH, 'images');
 const XZ_PATH = path.join(DATA_PATH, 'xz');
+const imageStream = require('../lib/index');
 const tester = require('./tester');
 
 describe('EtcherImageStream: XZ', function() {
 
   this.timeout(10000);
 
-  describe('given a xz image', function() {
-    tester.extractFromFilePath(
-      path.join(XZ_PATH, 'raspberrypi.img.xz'),
-      path.join(IMAGES_PATH, 'raspberrypi.img'));
+  describe('.getFromFilePath()', function() {
+
+    describe('given a xz image', function() {
+      tester.extractFromFilePath(
+        path.join(XZ_PATH, 'raspberrypi.img.xz'),
+        path.join(IMAGES_PATH, 'raspberrypi.img'));
+    });
+
+  });
+
+  describe('.getEstimatedFinalSize()', function() {
+
+    it('should return the correct estimated uncompressed size', function(done) {
+      const image = path.join(XZ_PATH, 'raspberrypi.img.xz');
+      const expectedSize = fs.statSync(path.join(IMAGES_PATH, 'raspberrypi.img')).size;
+
+      imageStream.getEstimatedFinalSize(image).then((estimatedSize) => {
+        m.chai.expect(estimatedSize).to.equal(expectedSize);
+        done();
+      });
+    });
+
   });
 
 });


### PR DESCRIPTION
This function is useful to determine the final size of an image after any
needed transformation, like decompression.

Its currently known to output incorrect results for Bzip2, since this
compression format provides no easy way to determine the uncompressed final
size.

Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>