### PR TITLE
Revert "Lock `lzma-native` to v1.4.1 (#19)"

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "bluebird": "^3.3.5",
     "gzip-uncompressed-size": "^1.0.0",
     "lodash": "^4.11.1",
-    "lzma-native": "1.4.1",
+    "lzma-native": "^1.1.0",
     "read-chunk": "^2.0.0",
     "rindle": "^1.3.0",
     "unbzip2-stream": "^1.0.9",


### PR DESCRIPTION
This reverts commit b796e0a9d6571136555bee6542ebeb567c92aaa6.

The issue was not introduced by a newer `lzma-native` version, but by an
Electron V8 upgrade.

Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>