### PR TITLE
Add support for `raw` images.

### DIFF
--- a/lib/supported.js
+++ b/lib/supported.js
@@ -48,5 +48,9 @@ module.exports = [
   {
     extension: 'hddimg',
     type: 'image'
+  },
+  {
+    extension: 'raw',
+    type: 'image'
   }
 ];


### PR DESCRIPTION
This kind of images are generated by
https://github.com/igorpecovnik/lib.

They behave exactly as `iso` or `img` extensions, therefore just adding
it to the supported file types array is enough.

Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>