### PR TITLE
Move from unzip2 to yauzl

### DIFF
--- a/lib/archive-hooks/zip.js
+++ b/lib/archive-hooks/zip.js
@@ -17,10 +17,9 @@
 'use strict';
 
 const Bluebird = require('bluebird');
-const fs = require('fs');
 const _ = require('lodash');
 const AdmZip = require('adm-zip');
-const unzip = require('unzip2');
+const yauzl = Bluebird.promisifyAll(require('yauzl'));
 
 /**
  * @summary Get all archive entries
@@ -83,15 +82,24 @@ exports.extractFile = (archive, file) => {
       throw new Error(`Invalid entry: ${file}`);
     }
 
-    fs.createReadStream(archive)
-      .pipe(unzip.Parse())
-      .on('error', reject)
-      .on('entry', (entry) => {
-        if (entry.type === 'File' && entry.path === file) {
-          return resolve(entry);
+    yauzl.openAsync(archive, {
+      lazyEntries: true
+    }).then((zipfile) => {
+      zipfile.readEntry();
+
+      zipfile.on('entry', (entry) => {
+        if (entry.fileName !== file) {
+          return zipfile.readEntry();
         }
 
-        entry.autodrain();
+        zipfile.openReadStream(entry, (error, readStream) => {
+          if (error) {
+            return reject(error);
+          }
+
+          return resolve(readStream);
+        });
       });
+    }).catch(reject);
   });
 };

--- a/package.json
+++ b/package.json
@@ -44,6 +44,6 @@
     "read-chunk": "^2.0.0",
     "rindle": "^1.3.0",
     "unbzip2-stream": "^1.0.9",
-    "unzip2": "^0.2.5"
+    "yauzl": "^2.6.0"
   }
 }


### PR DESCRIPTION
This new unzip library consumes much less CPU and RAM, plus it doesn't
gets stuck with certain malformed ZIP files.

See: https://github.com/resin-io/etcher/issues/410
See: https://github.com/thejoshwolfe/yauzl
Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>