### PR TITLE
Replace `.getEstimatedFinalSize` with a more generic `getImageMetatada`

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Documentation
 * [imageStream](#module_imageStream)
     * [.supportedFileTypes](#module_imageStream.supportedFileTypes) : <code>Array.&lt;String&gt;</code>
     * [.getFromFilePath(file)](#module_imageStream.getFromFilePath) ⇒ <code>Promise</code>
-    * [.getEstimatedFinalSize(file)](#module_imageStream.getEstimatedFinalSize) ⇒ <code>Promise</code>
+    * [.getImageMetatada(file)](#module_imageStream.getImageMetatada) ⇒ <code>Promise</code>
 
 <a name="module_imageStream.supportedFileTypes"></a>
 
@@ -78,20 +78,21 @@ imageStream.getFromFilePath('path/to/rpi.img.xz').then(function(image) {
     .pipe(fs.createWriteStream('/dev/disk2'));
 });
 ```
-<a name="module_imageStream.getEstimatedFinalSize"></a>
+<a name="module_imageStream.getImageMetatada"></a>
 
-### imageStream.getEstimatedFinalSize(file) ⇒ <code>Promise</code>
+### imageStream.getImageMetatada(file) ⇒ <code>Promise</code>
 This function is useful to determine the final size of an image
-after decompression or any other needed transformation.
+after decompression or any other needed transformation, as well as
+other relevent metadata, if any.
 
-**NOTE:** This function is known to output incorrect results for
+**NOTE:** This function is known to output incorrect size results for
 `bzip2`. For this compression format, this function will simply
 return the size of the compressed file.
 
 **Kind**: static method of <code>[imageStream](#module_imageStream)</code>  
-**Summary**: Get the estimated final size from image  
+**Summary**: Get image metadata  
 **Access:** public  
-**Fulfil**: <code>Number</code> - estimated final size  
+**Fulfil**: <code>Object</code> - image metadata  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -101,8 +102,11 @@ return the size of the compressed file.
 ```js
 const imageStream = require('etcher-image-stream');
 
-imageStream.getEstimatedFinalSize('path/to/rpi.img.xz').then(function(estimatedSize) {
-  console.log(`The estimated final size is: ${estimatedSize}`);
+imageStream.getImageMetatada('path/to/rpi.img.xz').then(function(metadata) {
+  console.log(`The image display name is: ${metada.name}`);
+  console.log(`The image url is: ${metada.url}`);
+  console.log(`The image logo is: ${metada.logo}`);
+  console.log(`The estimated final size is: ${metada.estimatedSize}`);
 });
 ```
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -20,6 +20,7 @@
 
 'use strict';
 
+const _ = require('lodash');
 const Bluebird = require('bluebird');
 const utils = require('./utils');
 const handlers = require('./handlers');
@@ -73,32 +74,41 @@ exports.getFromFilePath = function(file) {
 };
 
 /**
- * @summary Get the estimated final size from image
+ * @summary Get image metadata
  * @function
  * @public
  *
  * @description
  * This function is useful to determine the final size of an image
- * after decompression or any other needed transformation.
+ * after decompression or any other needed transformation, as well as
+ * other relevent metadata, if any.
  *
- * **NOTE:** This function is known to output incorrect results for
+ * **NOTE:** This function is known to output incorrect size results for
  * `bzip2`. For this compression format, this function will simply
  * return the size of the compressed file.
  *
  * @param {String} file - file path
- * @fulfil {Number} - estimated final size
+ * @fulfil {Object} - image metadata
  * @returns {Promise}
  *
  * @example
  * const imageStream = require('etcher-image-stream');
  *
- * imageStream.getEstimatedFinalSize('path/to/rpi.img.xz').then(function(estimatedSize) {
- *   console.log(`The estimated final size is: ${estimatedSize}`);
+ * imageStream.getImageMetatada('path/to/rpi.img.xz').then(function(metadata) {
+ *   console.log(`The image display name is: ${metada.name}`);
+ *   console.log(`The image url is: ${metada.url}`);
+ *   console.log(`The image logo is: ${metada.logo}`);
+ *   console.log(`The estimated final size is: ${metada.estimatedSize}`);
  * });
  */
-exports.getEstimatedFinalSize = function(file) {
+exports.getImageMetatada = function(file) {
   return exports.getFromFilePath(file).then(function(image) {
-    return image.estimatedUncompressedSize || image.size;
+    return _.omitBy({
+      estimatedSize: image.estimatedUncompressedSize || image.size,
+      name: image.name,
+      url: image.url,
+      logo: image.logo
+    }, _.isUndefined);
   });
 };
 

--- a/tests/bz2.spec.js
+++ b/tests/bz2.spec.js
@@ -39,14 +39,16 @@ describe('EtcherImageStream: BZ2', function() {
 
   });
 
-  describe('.getEstimatedFinalSize()', function() {
+  describe('.getImageMetatada()', function() {
 
-    it('should return the compressed size', function(done) {
+    it('should return the correct metadata', function(done) {
       const image = path.join(BZ2_PATH, 'raspberrypi.img.bz2');
       const expectedSize = fs.statSync(image).size;
 
-      imageStream.getEstimatedFinalSize(image).then((estimatedSize) => {
-        m.chai.expect(estimatedSize).to.equal(expectedSize);
+      imageStream.getImageMetatada(image).then((metadata) => {
+        m.chai.expect(metadata).to.deep.equal({
+          estimatedSize: expectedSize
+        });
         done();
       });
     });

--- a/tests/gz.spec.js
+++ b/tests/gz.spec.js
@@ -39,14 +39,16 @@ describe('EtcherImageStream: GZ', function() {
 
   });
 
-  describe('.getEstimatedFinalSize()', function() {
+  describe('.getImageMetatada()', function() {
 
-    it('should return the correct estimated uncompressed size', function(done) {
+    it('should return the correct metadata', function(done) {
       const image = path.join(GZ_PATH, 'raspberrypi.img.gz');
       const expectedSize = fs.statSync(path.join(IMAGES_PATH, 'raspberrypi.img')).size;
 
-      imageStream.getEstimatedFinalSize(image).then((estimatedSize) => {
-        m.chai.expect(estimatedSize).to.equal(expectedSize);
+      imageStream.getImageMetatada(image).then((metadata) => {
+        m.chai.expect(metadata).to.deep.equal({
+          estimatedSize: expectedSize
+        });
         done();
       });
     });

--- a/tests/img.spec.js
+++ b/tests/img.spec.js
@@ -38,14 +38,16 @@ describe('EtcherImageStream: IMG', function() {
 
   });
 
-  describe('.getEstimatedFinalSize()', function() {
+  describe('.getImageMetatada()', function() {
 
-    it('should return the file size', function(done) {
+    it('should return the correct metadata', function(done) {
       const image = path.join(IMAGES_PATH, 'raspberrypi.img');
       const expectedSize = fs.statSync(image).size;
 
-      imageStream.getEstimatedFinalSize(image).then((estimatedSize) => {
-        m.chai.expect(estimatedSize).to.equal(expectedSize);
+      imageStream.getImageMetatada(image).then((metadata) => {
+        m.chai.expect(metadata).to.deep.equal({
+          estimatedSize: expectedSize
+        });
         done();
       });
     });

--- a/tests/metadata/zip.spec.js
+++ b/tests/metadata/zip.spec.js
@@ -34,6 +34,20 @@ describe('EtcherImageStream: Metadata ZIP', function() {
       path.join(ZIP_PATH, 'rpi-invalid-manifest.zip'),
       'Invalid archive manifest.json');
 
+    describe('.getImageMetatada()', function() {
+
+      it('should be rejected with an error', function(done) {
+        const image = path.join(ZIP_PATH, 'rpi-invalid-manifest.zip');
+
+        imageStream.getImageMetatada(image).catch((error) => {
+          m.chai.expect(error).to.be.an.instanceof(Error);
+          m.chai.expect(error.message).to.equal('Invalid archive manifest.json');
+          done();
+        });
+      });
+
+    });
+
   });
 
   describe('given an archive with a `manifest.json`', function() {
@@ -58,22 +72,47 @@ describe('EtcherImageStream: Metadata ZIP', function() {
       });
     });
 
+    describe('.getImageMetatada()', function() {
+
+      it('should resolve the correct metadata', function(done) {
+        imageStream.getImageMetatada(archive).then((metadata) => {
+          m.chai.expect(metadata.name).to.equal('Raspberry Pi');
+          m.chai.expect(metadata.url).to.equal('https://www.raspberrypi.org');
+          done();
+        });
+      });
+
+    });
+
   });
 
   describe('given an archive with a `logo.svg`', function() {
 
     const archive = path.join(ZIP_PATH, 'rpi-with-logo.zip');
 
+    const logo = [
+      '<svg xmlns="http://www.w3.org/2000/svg">',
+      '  <text>Hello World</text>',
+      '</svg>',
+      ''
+    ].join('\n');
+
     it('should read the logo contents', function(done) {
       imageStream.getFromFilePath(archive).then((image) => {
-        m.chai.expect(image.logo).to.equal([
-          '<svg xmlns="http://www.w3.org/2000/svg">',
-          '  <text>Hello World</text>',
-          '</svg>',
-          ''
-        ].join('\n'));
+        m.chai.expect(image.logo).to.equal(logo);
         done();
       });
+    });
+
+    describe('.getImageMetatada()', function() {
+
+      it('should include the logo in the', function(done) {
+        imageStream.getImageMetatada(archive).then((metadata) => {
+          m.chai.expect(metadata.logo).to.equal(logo);
+          done();
+        });
+      });
+
     });
 
   });

--- a/tests/xz.spec.js
+++ b/tests/xz.spec.js
@@ -39,14 +39,16 @@ describe('EtcherImageStream: XZ', function() {
 
   });
 
-  describe('.getEstimatedFinalSize()', function() {
+  describe('.getImageMetatada()', function() {
 
-    it('should return the correct estimated uncompressed size', function(done) {
+    it('should return the correct metadata', function(done) {
       const image = path.join(XZ_PATH, 'raspberrypi.img.xz');
       const expectedSize = fs.statSync(path.join(IMAGES_PATH, 'raspberrypi.img')).size;
 
-      imageStream.getEstimatedFinalSize(image).then((estimatedSize) => {
-        m.chai.expect(estimatedSize).to.equal(expectedSize);
+      imageStream.getImageMetatada(image).then((metadata) => {
+        m.chai.expect(metadata).to.deep.equal({
+          estimatedSize: expectedSize
+        });
         done();
       });
     });

--- a/tests/zip.spec.js
+++ b/tests/zip.spec.js
@@ -63,14 +63,16 @@ describe('EtcherImageStream: ZIP', function() {
 
   });
 
-  describe('.getEstimatedFinalSize()', function() {
+  describe('.getImageMetatada()', function() {
 
-    it('should return the correct estimated uncompressed size', function(done) {
+    it('should return the correct metadata', function(done) {
       const image = path.join(ZIP_PATH, 'zip-directory-rpi-only.zip');
       const expectedSize = fs.statSync(path.join(IMAGES_PATH, 'raspberrypi.img')).size;
 
-      imageStream.getEstimatedFinalSize(image).then((estimatedSize) => {
-        m.chai.expect(estimatedSize).to.equal(expectedSize);
+      imageStream.getImageMetatada(image).then((metadata) => {
+        m.chai.expect(metadata).to.deep.equal({
+          estimatedSize: expectedSize
+        });
         done();
       });
     });


### PR DESCRIPTION
Instead of having a function that just returns the estimated final size,
it makes more sense to have a function that returns every image metadata
it can get from the image, including but not limited to the estimated
final size.

When being used on Zip archives with extra metadata, this function
returns the image name, url, logo, etc.

Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>