### PR TITLE
Improve speed when retrieving an archive metadata

### DIFF
--- a/lib/archive-hooks/zip.js
+++ b/lib/archive-hooks/zip.js
@@ -63,19 +63,19 @@ exports.getEntries = (archive) => {
  * @public
  *
  * @param {String} archive - archive path
+ * @param {String[]} entries - archive entries
  * @param {String} file - archive file
  * @fulfil {ReadableStream} file
  * @returns {Promise}
  *
  * @example
- * zip.extractFile('path/to/my.zip', 'my/file').then((stream) => {
+ * const entries = zip.getEntries('path/to/my.zip');
+ * zip.extractFile('path/to/my.zip', entries, 'my/file').then((stream) => {
  *   stream.pipe('...');
  * });
  */
-exports.extractFile = (archive, file) => {
+exports.extractFile = (archive, entries, file) => {
   return new Bluebird((resolve, reject) => {
-    const entries = exports.getEntries(archive);
-
     if (!_.find(entries, {
       name: file
     })) {

--- a/lib/archive.js
+++ b/lib/archive.js
@@ -46,19 +46,21 @@ const IMAGE_EXTENSIONS = _.reduce(supportedFileTypes, (accumulator, file) => {
  * @param {String} filePath - entry file path
  * @param {Object} options - options
  * @param {Object} options.hooks - archive hooks
+ * @param {Object[]} options.entries - archive entries
  * @param {*} [options.default] - entry default value
  * @fulfil {*} contents
  * @returns {Promise}
  *
  * extractEntryByPath('my/archive.zip', '_info/logo.svg', {
  *   hooks: { ... },
+ *   entries: [ ... ],
  *   default: ''
  * }).then((contents) => {
  *   console.log(contents);
  * });
  */
 const extractEntryByPath = (archive, filePath, options) => {
-  const fileEntry = _.find(options.hooks.getEntries(archive), (entry) => {
+  const fileEntry = _.find(options.entries, (entry) => {
     return _.chain(entry.name)
       .split('/')
       .tail()
@@ -70,7 +72,7 @@ const extractEntryByPath = (archive, filePath, options) => {
     return Bluebird.resolve(options.default);
   }
 
-  return options.hooks.extractFile(archive, fileEntry.name)
+  return options.hooks.extractFile(archive, options.entries, fileEntry.name)
     .then(rindle.extract);
 };
 
@@ -91,7 +93,7 @@ const extractEntryByPath = (archive, filePath, options) => {
  *   getEntries: (archive) => {
  *     return [ ..., ..., ... ];
  *   },
- *   extractFile: (archive, file) => {
+ *   extractFile: (archive, entries, file) => {
  *     ...
  *   }
  * }).then((image) => {
@@ -113,16 +115,19 @@ exports.extractImage = (archive, hooks) => {
   const imageEntry = _.first(imageEntries);
 
   return Bluebird.props({
-    imageStream: hooks.extractFile(archive, imageEntry.name),
+    imageStream: hooks.extractFile(archive, entries, imageEntry.name),
     logo: extractEntryByPath(archive, '_info/logo.svg', {
-      hooks
+      hooks,
+      entries
     }),
     bmap: extractEntryByPath(archive, '_info/image.bmap', {
-      hooks
+      hooks,
+      entries
     }),
     manifest: _.attempt(() => {
       return extractEntryByPath(archive, '_info/manifest.json', {
         hooks,
+        entries,
         default: '{}'
       }).then((manifest) => {
         try {

--- a/tests/archive-hooks/zip.spec.js
+++ b/tests/archive-hooks/zip.spec.js
@@ -91,11 +91,12 @@ describe('Archive hooks: ZIP', function() {
 
     beforeEach(function() {
       this.zip = path.join(ZIP_PATH, 'zip-directory-nested-misc.zip');
+      this.entries = zipHooks.getEntries(this.zip);
     });
 
     it('should be able to extract a top-level file', function(done) {
       const fileName = 'zip-directory-nested-misc/foo';
-      zipHooks.extractFile(this.zip, fileName).then((stream) => {
+      zipHooks.extractFile(this.zip, this.entries, fileName).then((stream) => {
         rindle.extract(stream, function(error, data) {
           m.chai.expect(error).to.not.exist;
           m.chai.expect(data).to.equal('foo\n');
@@ -106,7 +107,7 @@ describe('Archive hooks: ZIP', function() {
 
     it('should be able to extract a nested file', function(done) {
       const fileName = 'zip-directory-nested-misc/hello/there/bar';
-      zipHooks.extractFile(this.zip, fileName).then((stream) => {
+      zipHooks.extractFile(this.zip, this.entries, fileName).then((stream) => {
         rindle.extract(stream, function(error, data) {
           m.chai.expect(error).to.not.exist;
           m.chai.expect(data).to.equal('bar\n');
@@ -117,7 +118,7 @@ describe('Archive hooks: ZIP', function() {
 
     it('should throw if the entry does not exist', function(done) {
       const fileName = 'zip-directory-nested-misc/xxxxxxxxxxxxxxxx';
-      zipHooks.extractFile(this.zip, fileName).catch((error) => {
+      zipHooks.extractFile(this.zip, this.entries, fileName).catch((error) => {
         m.chai.expect(error).to.be.an.instanceof(Error);
         m.chai.expect(error.message).to.equal(`Invalid entry: ${fileName}`);
         done();
@@ -126,7 +127,7 @@ describe('Archive hooks: ZIP', function() {
 
     it('should throw if the entry is a directory', function(done) {
       const fileName = 'zip-directory-nested-misc/hello';
-      zipHooks.extractFile(this.zip, fileName).catch((error) => {
+      zipHooks.extractFile(this.zip, this.entries, fileName).catch((error) => {
         m.chai.expect(error).to.be.an.instanceof(Error);
         m.chai.expect(error.message).to.equal(`Invalid entry: ${fileName}`);
         done();


### PR DESCRIPTION
Currently, analysing an archive (e.g: a ZIP) and returning all its
metadata its an slow operation. After some investigation, this was
mainly caused by not reusing the information about available entries and
fetching this information over and over again.

With the following optimisations, the `.getEntries()` function is only
called once. The following benchmarkings were done on a
`Jessie_PiTFT28c.zip` image:

Before:

```
$ time node benchmark.js
node benchmark.js  0.36s user 5.16s system 99% cpu 5.568 total
```

After:

```
$ time node benchmark.js
node benchmark.js  0.35s user 1.03s system 100% cpu 1.373 total
```

Consider that this image doesn't contain extra metadata like a logo, or
a bmap file. If it would, the gains would be probably even larger.

Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>