### PR TITLE
Replace AdmZip with StreamZip for reading zip entries

### DIFF
--- a/lib/archive-hooks/zip.js
+++ b/lib/archive-hooks/zip.js
@@ -18,7 +18,7 @@
 
 const Bluebird = require('bluebird');
 const _ = require('lodash');
-const AdmZip = require('adm-zip');
+const StreamZip = require('node-stream-zip');
 const yauzl = Bluebird.promisifyAll(require('yauzl'));
 
 /**
@@ -27,34 +27,40 @@ const yauzl = Bluebird.promisifyAll(require('yauzl'));
  * @public
  *
  * @param {String} archive - archive path
- * @returns {Object[]} archive entries
+ * @fulfil {Object[]} - archive entries
+ * @returns {Promise}
  *
  * @example
- * const entries = zip.getEntries('path/to/my.zip');
- *
- * entries.forEach((entry) => {
- *   console.log(entry.name);
- *   console.log(entry.size);
+ * zip.getEntries('path/to/my.zip').then((entries) => {
+ *   entries.forEach((entry) => {
+ *     console.log(entry.name);
+ *     console.log(entry.size);
+ *   });
  * });
  */
 exports.getEntries = (archive) => {
-  const admZip = new AdmZip(archive);
+  return new Bluebird((resolve, reject) => {
+    const zip = new StreamZip({
+      file: archive,
+      storeEntries: true
+    });
 
-  return _.chain(admZip.getEntries())
-    .reject((entry) => {
-      return _.some([
-        entry.name === '.',
-        entry.name === '',
-        entry.size === 0
-      ]);
-    })
-    .map((entry) => {
-      return {
-        name: entry.entryName,
-        size: entry.header.size
-      };
-    })
-    .value();
+    zip.on('error', reject);
+
+    zip.on('ready', function() {
+      return resolve(_.chain(zip.entries())
+        .omitBy((entry) => {
+          return entry.size === 0;
+        })
+        .map((metadata) => {
+          return {
+            name: metadata.name,
+            size: metadata.size
+          };
+        })
+        .value());
+    });
+  });
 };
 
 /**
@@ -69,8 +75,9 @@ exports.getEntries = (archive) => {
  * @returns {Promise}
  *
  * @example
- * const entries = zip.getEntries('path/to/my.zip');
- * zip.extractFile('path/to/my.zip', entries, 'my/file').then((stream) => {
+ * zip.getEntries('path/to/my.zip').then((entries) => {
+ *   return zip.extractFile('path/to/my.zip', entries, 'my/file');
+ * }).then((stream) => {
  *   stream.pipe('...');
  * });
  */

--- a/lib/archive.js
+++ b/lib/archive.js
@@ -101,51 +101,52 @@ const extractEntryByPath = (archive, filePath, options) => {
  * });
  */
 exports.extractImage = (archive, hooks) => {
-  const entries = hooks.getEntries(archive);
+  return hooks.getEntries(archive).then((entries) => {
 
-  const imageEntries = _.filter(entries, (entry) => {
-    const extension = path.extname(entry.name).slice(1);
-    return _.includes(IMAGE_EXTENSIONS, extension);
-  });
+    const imageEntries = _.filter(entries, (entry) => {
+      const extension = path.extname(entry.name).slice(1);
+      return _.includes(IMAGE_EXTENSIONS, extension);
+    });
 
-  if (imageEntries.length !== 1) {
-    throw new Error('Invalid archive image');
-  }
+    if (imageEntries.length !== 1) {
+      throw new Error('Invalid archive image');
+    }
 
-  const imageEntry = _.first(imageEntries);
+    const imageEntry = _.first(imageEntries);
 
-  return Bluebird.props({
-    imageStream: hooks.extractFile(archive, entries, imageEntry.name),
-    logo: extractEntryByPath(archive, '_info/logo.svg', {
-      hooks,
-      entries
-    }),
-    bmap: extractEntryByPath(archive, '_info/image.bmap', {
-      hooks,
-      entries
-    }),
-    manifest: _.attempt(() => {
-      return extractEntryByPath(archive, '_info/manifest.json', {
+    return Bluebird.props({
+      imageStream: hooks.extractFile(archive, entries, imageEntry.name),
+      logo: extractEntryByPath(archive, '_info/logo.svg', {
         hooks,
-        entries,
-        default: '{}'
-      }).then((manifest) => {
-        try {
-          return JSON.parse(manifest);
-        } catch (error) {
-          throw new Error('Invalid archive manifest.json');
-        }
-      });
-    })
-  }).then((results) => {
-    return {
-      stream: results.imageStream,
-      size: imageEntry.size,
-      name: results.manifest.name,
-      url: results.manifest.url,
-      logo: results.logo,
-      bmap: results.bmap,
-      transform: new PassThroughStream()
-    };
+        entries
+      }),
+      bmap: extractEntryByPath(archive, '_info/image.bmap', {
+        hooks,
+        entries
+      }),
+      manifest: _.attempt(() => {
+        return extractEntryByPath(archive, '_info/manifest.json', {
+          hooks,
+          entries,
+          default: '{}'
+        }).then((manifest) => {
+          try {
+            return JSON.parse(manifest);
+          } catch (error) {
+            throw new Error('Invalid archive manifest.json');
+          }
+        });
+      })
+    }).then((results) => {
+      return {
+        stream: results.imageStream,
+        size: imageEntry.size,
+        name: results.manifest.name,
+        url: results.manifest.url,
+        logo: results.logo,
+        bmap: results.bmap,
+        transform: new PassThroughStream()
+      };
+    });
   });
 };

--- a/package.json
+++ b/package.json
@@ -35,12 +35,12 @@
     "tmp": "0.0.28"
   },
   "dependencies": {
-    "adm-zip": "^0.4.7",
     "archive-type": "^3.2.0",
     "bluebird": "^3.3.5",
     "gzip-uncompressed-size": "^1.0.0",
     "lodash": "^4.11.1",
     "lzma-native": "^1.1.0",
+    "node-stream-zip": "^1.3.4",
     "read-chunk": "^2.0.0",
     "rindle": "^1.3.0",
     "unbzip2-stream": "^1.0.9",

--- a/tests/archive-hooks/zip.spec.js
+++ b/tests/archive-hooks/zip.spec.js
@@ -32,9 +32,10 @@ describe('Archive hooks: ZIP', function() {
         this.zip = path.join(ZIP_PATH, 'zip-directory-empty.zip');
       });
 
-      it('should return an empty array', function() {
-        const entries = zipHooks.getEntries(this.zip);
-        m.chai.expect(entries).to.deep.equal([]);
+      it('should become an empty array', function(done) {
+        zipHooks.getEntries(this.zip).then((entries) => {
+          m.chai.expect(entries).to.deep.equal([]);
+        }).asCallback(done);
       });
 
     });
@@ -45,19 +46,19 @@ describe('Archive hooks: ZIP', function() {
         this.zip = path.join(ZIP_PATH, 'zip-directory-multiple-images.zip');
       });
 
-      it('should return all entries', function() {
-        const entries = zipHooks.getEntries(this.zip);
-
-        m.chai.expect(entries).to.deep.equal([
-          {
-            name: 'multiple-images/edison-config.img',
-            size: 16777216
-          },
-          {
-            name: 'multiple-images/raspberrypi.img',
-            size: 33554432
-          }
-        ]);
+      it('should become all entries', function(done) {
+        zipHooks.getEntries(this.zip).then((entries) => {
+          m.chai.expect(entries).to.deep.equal([
+            {
+              name: 'multiple-images/edison-config.img',
+              size: 16777216
+            },
+            {
+              name: 'multiple-images/raspberrypi.img',
+              size: 33554432
+            }
+          ]);
+        }).asCallback(done);
       });
 
     });
@@ -68,19 +69,19 @@ describe('Archive hooks: ZIP', function() {
         this.zip = path.join(ZIP_PATH, 'zip-directory-nested-misc.zip');
       });
 
-      it('should return all entries', function() {
-        const entries = zipHooks.getEntries(this.zip);
-
-        m.chai.expect(entries).to.deep.equal([
-          {
-            name: 'zip-directory-nested-misc/foo',
-            size: 4
-          },
-          {
-            name: 'zip-directory-nested-misc/hello/there/bar',
-            size: 4
-          }
-        ]);
+      it('should become all entries', function(done) {
+        zipHooks.getEntries(this.zip).then((entries) => {
+          m.chai.expect(entries).to.deep.equal([
+            {
+              name: 'zip-directory-nested-misc/foo',
+              size: 4
+            },
+            {
+              name: 'zip-directory-nested-misc/hello/there/bar',
+              size: 4
+            }
+          ]);
+        }).asCallback(done);
       });
 
     });
@@ -91,12 +92,13 @@ describe('Archive hooks: ZIP', function() {
 
     beforeEach(function() {
       this.zip = path.join(ZIP_PATH, 'zip-directory-nested-misc.zip');
-      this.entries = zipHooks.getEntries(this.zip);
     });
 
     it('should be able to extract a top-level file', function(done) {
       const fileName = 'zip-directory-nested-misc/foo';
-      zipHooks.extractFile(this.zip, this.entries, fileName).then((stream) => {
+      zipHooks.getEntries(this.zip).then((entries) => {
+        return zipHooks.extractFile(this.zip, entries, fileName);
+      }).then((stream) => {
         rindle.extract(stream, function(error, data) {
           m.chai.expect(error).to.not.exist;
           m.chai.expect(data).to.equal('foo\n');
@@ -107,7 +109,9 @@ describe('Archive hooks: ZIP', function() {
 
     it('should be able to extract a nested file', function(done) {
       const fileName = 'zip-directory-nested-misc/hello/there/bar';
-      zipHooks.extractFile(this.zip, this.entries, fileName).then((stream) => {
+      zipHooks.getEntries(this.zip).then((entries) => {
+        return zipHooks.extractFile(this.zip, entries, fileName);
+      }).then((stream) => {
         rindle.extract(stream, function(error, data) {
           m.chai.expect(error).to.not.exist;
           m.chai.expect(data).to.equal('bar\n');
@@ -118,7 +122,9 @@ describe('Archive hooks: ZIP', function() {
 
     it('should throw if the entry does not exist', function(done) {
       const fileName = 'zip-directory-nested-misc/xxxxxxxxxxxxxxxx';
-      zipHooks.extractFile(this.zip, this.entries, fileName).catch((error) => {
+      zipHooks.getEntries(this.zip).then((entries) => {
+        return zipHooks.extractFile(this.zip, entries, fileName);
+      }).catch((error) => {
         m.chai.expect(error).to.be.an.instanceof(Error);
         m.chai.expect(error.message).to.equal(`Invalid entry: ${fileName}`);
         done();
@@ -127,7 +133,9 @@ describe('Archive hooks: ZIP', function() {
 
     it('should throw if the entry is a directory', function(done) {
       const fileName = 'zip-directory-nested-misc/hello';
-      zipHooks.extractFile(this.zip, this.entries, fileName).catch((error) => {
+      zipHooks.getEntries(this.zip).then((entries) => {
+        return zipHooks.extractFile(this.zip, entries, fileName);
+      }).catch((error) => {
         m.chai.expect(error).to.be.an.instanceof(Error);
         m.chai.expect(error.message).to.equal(`Invalid entry: ${fileName}`);
         done();


### PR DESCRIPTION
AdmZip has a bug that causes it to return very wrong entry sizes for
certain zip files that are either not very well formed, or were
compressed by non mainstream programs.

See: https://github.com/resin-io/etcher/issues/644
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>