### PR TITLE
Remove `estimatedSize` property from metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,6 @@ imageStream.getImageMetadata('path/to/rpi.img.xz').then(function(metadata) {
   console.log(`The image url is: ${metada.url}`);
   console.log(`The image support url is: ${metada.supportUrl}`);
   console.log(`The image logo is: ${metada.logo}`);
-  console.log(`The estimated final size is: ${metada.estimatedSize}`);
 });
 ```
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -70,6 +70,8 @@ exports.getFromFilePath = function(file) {
     }
 
     return handlers[type](file);
+  }).then((image) => {
+    return _.omitBy(image, _.isUndefined);
   });
 };
 
@@ -99,21 +101,11 @@ exports.getFromFilePath = function(file) {
  *   console.log(`The image url is: ${metada.url}`);
  *   console.log(`The image support url is: ${metada.supportUrl}`);
  *   console.log(`The image logo is: ${metada.logo}`);
- *   console.log(`The estimated final size is: ${metada.estimatedSize}`);
  * });
  */
 exports.getImageMetadata = function(file) {
-  return exports.getFromFilePath(file).then(function(image) {
-    return _.omitBy({
-      estimatedSize: image.estimatedUncompressedSize || image.size,
-      name: image.name,
-      version: image.version,
-      url: image.url,
-      supportUrl: image.supportUrl,
-      releaseNotesUrl: image.releaseNotesUrl,
-      bmap: image.bmap,
-      logo: image.logo
-    }, _.isUndefined);
+  return exports.getFromFilePath(file).then((image) => {
+    return _.omitBy(image, _.isObject);
   });
 };
 

--- a/tests/bz2.spec.js
+++ b/tests/bz2.spec.js
@@ -47,7 +47,7 @@ describe('EtcherImageStream: BZ2', function() {
 
       imageStream.getImageMetadata(image).then((metadata) => {
         m.chai.expect(metadata).to.deep.equal({
-          estimatedSize: expectedSize
+          size: expectedSize
         });
         done();
       });

--- a/tests/gz.spec.js
+++ b/tests/gz.spec.js
@@ -44,10 +44,12 @@ describe('EtcherImageStream: GZ', function() {
     it('should return the correct metadata', function(done) {
       const image = path.join(GZ_PATH, 'raspberrypi.img.gz');
       const expectedSize = fs.statSync(path.join(IMAGES_PATH, 'raspberrypi.img')).size;
+      const size = fs.statSync(path.join(GZ_PATH, 'raspberrypi.img.gz')).size;
 
       imageStream.getImageMetadata(image).then((metadata) => {
         m.chai.expect(metadata).to.deep.equal({
-          estimatedSize: expectedSize
+          estimatedUncompressedSize: expectedSize,
+          size: size
         });
         done();
       });

--- a/tests/img.spec.js
+++ b/tests/img.spec.js
@@ -46,7 +46,7 @@ describe('EtcherImageStream: IMG', function() {
 
       imageStream.getImageMetadata(image).then((metadata) => {
         m.chai.expect(metadata).to.deep.equal({
-          estimatedSize: expectedSize
+          size: expectedSize
         });
         done();
       });

--- a/tests/xz.spec.js
+++ b/tests/xz.spec.js
@@ -47,7 +47,7 @@ describe('EtcherImageStream: XZ', function() {
 
       imageStream.getImageMetadata(image).then((metadata) => {
         m.chai.expect(metadata).to.deep.equal({
-          estimatedSize: expectedSize
+          size: expectedSize
         });
         done();
       });

--- a/tests/zip.spec.js
+++ b/tests/zip.spec.js
@@ -71,7 +71,7 @@ describe('EtcherImageStream: ZIP', function() {
 
       imageStream.getImageMetadata(image).then((metadata) => {
         m.chai.expect(metadata).to.deep.equal({
-          estimatedSize: expectedSize
+          size: expectedSize
         });
         done();
       });


### PR DESCRIPTION
We currently show the following size-related properties:

- `size`
- `estimatedUncompressedSize`
- `estimatedSize` (based on the previous two)

Which is really confusing for the end user.

As a solution, we only return `size` and `estimatedUncompressedSize`,
which have obvious meaning, and let the end user determine what a final
"estimated size" is.

The change introduced above allows for some small refactoring, which is
done on this PR as well.

Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>