### PR TITLE
Add `bytesToZeroOutFromTheBeginning` to archive metadata `manifest.json`

### DIFF
--- a/lib/archive.js
+++ b/lib/archive.js
@@ -148,6 +148,7 @@ exports.extractImage = (archive, hooks) => {
         releaseNotesUrl: results.manifest.releaseNotesUrl,
         checksumType: results.manifest.checksumType,
         checksum: results.manifest.checksum,
+        bytesToZeroOutFromTheBeginning: results.manifest.bytesToZeroOutFromTheBeginning,
         logo: results.logo,
         bmap: results.bmap,
         transform: new PassThroughStream()

--- a/tests/metadata/zip.spec.js
+++ b/tests/metadata/zip.spec.js
@@ -98,6 +98,10 @@ describe('EtcherImageStream: Metadata ZIP', function() {
       testMetadataProperty(archive, 'checksum', 'add060b285d512f56c175b76b7ef1bee').asCallback(done);
     });
 
+    it('should read the manifest bytesToZeroOutFromTheBeginning property', function(done) {
+      testMetadataProperty(archive, 'bytesToZeroOutFromTheBeginning', 512).asCallback(done);
+    });
+
   });
 
   describe('given an archive with a `logo.svg`', function() {


### PR DESCRIPTION
This option will be proxied to `bmapflash`'s
`bytesToZeroOutFromTheBeginning`' option.

See: https://github.com/resin-io-modules/bmapflash/pull/6
See: https://github.com/resin-io/etcher/issues/673
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>