### PR TITLE
Add support for markdown instructions at `_info/instructions.markdown`

### DIFF
--- a/lib/archive.js
+++ b/lib/archive.js
@@ -120,6 +120,10 @@ exports.extractImage = (archive, hooks) => {
         hooks,
         entries
       }),
+      instructions: extractEntryByPath(archive, '_info/instructions.markdown', {
+        hooks,
+        entries
+      }),
       bmap: extractEntryByPath(archive, '_info/image.bmap', {
         hooks,
         entries
@@ -151,6 +155,7 @@ exports.extractImage = (archive, hooks) => {
         bytesToZeroOutFromTheBeginning: results.manifest.bytesToZeroOutFromTheBeginning,
         logo: results.logo,
         bmap: results.bmap,
+        instructions: results.instructions,
         transform: new PassThroughStream()
       };
     });

--- a/tests/metadata/zip.spec.js
+++ b/tests/metadata/zip.spec.js
@@ -147,4 +147,21 @@ describe('EtcherImageStream: Metadata ZIP', function() {
 
   });
 
+  describe('given an archive with instructions', function() {
+
+    const archive = path.join(ZIP_PATH, 'rpi-with-instructions.zip');
+
+    const instructions = [
+      '# Raspberry Pi Next Steps',
+      '',
+      'Lorem ipsum dolor sit amet.',
+      ''
+    ].join('\n');
+
+    it('should read the instruction contents', function(done) {
+      testMetadataProperty(archive, 'instructions', instructions).asCallback(done);
+    });
+
+  });
+
 });


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>