### PR TITLE
Add `recommendedDriveSize` to archive metadata `manifest.json`

### DIFF
--- a/lib/archive.js
+++ b/lib/archive.js
@@ -153,6 +153,7 @@ exports.extractImage = (archive, hooks) => {
         checksumType: results.manifest.checksumType,
         checksum: results.manifest.checksum,
         bytesToZeroOutFromTheBeginning: results.manifest.bytesToZeroOutFromTheBeginning,
+        recommendedDriveSize: results.manifest.recommendedDriveSize,
         logo: results.logo,
         bmap: results.bmap,
         instructions: results.instructions,

--- a/tests/metadata/zip.spec.js
+++ b/tests/metadata/zip.spec.js
@@ -102,6 +102,10 @@ describe('EtcherImageStream: Metadata ZIP', function() {
       testMetadataProperty(archive, 'bytesToZeroOutFromTheBeginning', 512).asCallback(done);
     });
 
+    it('should read the manifest recommendedDriveSize property', function(done) {
+      testMetadataProperty(archive, 'recommendedDriveSize', 4294967296).asCallback(done);
+    });
+
   });
 
   describe('given an archive with a `logo.svg`', function() {


### PR DESCRIPTION
This property, expressed in bytes, will be used to warn the user that
the drive, while large enough to hold the image, might not be large
enough for proper usage later on.

Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>