### PR TITLE
Upgrade unbzip2-stream to v1.0.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "node-stream-zip": "^1.3.4",
     "read-chunk": "^2.0.0",
     "rindle": "^1.3.0",
-    "unbzip2-stream": "^1.0.9",
+    "unbzip2-stream": "^1.0.10",
     "yauzl": "^2.6.0"
   }
 }


### PR DESCRIPTION
This version contains a fix that prevents a JavaScript uncaught errors
in certain bz2 files (mostly large ones).

See: https://github.com/regular/unbzip2-stream/issues/7
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>