### PR TITLE
Add a `.description` property to all archive related errors

### DIFF
--- a/lib/archive.js
+++ b/lib/archive.js
@@ -117,8 +117,10 @@ const extractArchiveMetadata = (archive, basePath, options) => {
       }).then((manifest) => {
         try {
           return JSON.parse(manifest);
-        } catch (error) {
-          throw new Error('Invalid archive manifest.json');
+        } catch (parseError) {
+          const error = new Error('Invalid archive manifest.json');
+          error.description = 'The archive manifest.json file is not valid JSON.';
+          throw error;
         }
       });
     })
@@ -173,7 +175,9 @@ exports.extractImage = (archive, hooks) => {
     });
 
     if (imageEntries.length !== 1) {
-      throw new Error('Invalid archive image');
+      const error = new Error('Invalid archive image');
+      error.description = 'The archive image should contain one and only one top image file.';
+      throw error;
     }
 
     const imageEntry = _.first(imageEntries);

--- a/tests/tester.js
+++ b/tests/tester.js
@@ -43,9 +43,14 @@ const deleteIfExists = (file) => {
 };
 
 exports.expectError = function(file, errorMessage) {
-  it('should be rejected with an error', function() {
-    const promise = imageStream.getFromFilePath(file);
-    m.chai.expect(promise).to.be.rejectedWith(errorMessage);
+  it('should be rejected with an error', function(done) {
+    return imageStream.getFromFilePath(file).catch((error) => {
+      m.chai.expect(error).to.be.an.instanceof(Error);
+      m.chai.expect(error.message).to.equal(errorMessage);
+      m.chai.expect(error.description).to.be.a.string;
+      m.chai.expect(error.description.length > 0).to.be.true;
+      done();
+    });
   });
 };
 


### PR DESCRIPTION
Etcher uses the `.description` property to provide a nice dialog instead
of just throwing the stack trace to the user.

See: https://github.com/resin-io/etcher/issues/731
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>