### PR TITLE
Add support for `.cdr` images.

### DIFF
--- a/lib/supported.js
+++ b/lib/supported.js
@@ -46,6 +46,10 @@ module.exports = [
     type: 'image'
   },
   {
+    extension: 'cdr',
+    type: 'image'
+  },
+  {
     extension: 'dsk',
     type: 'image'
   },


### PR DESCRIPTION
`.cdr` images are basically `.iso`, however they get named that way in
certain OS X systems:

> ISO image files typically have a file extension of .ISO but Mac OS X
> ISO images often have the extension .CDR.

See: https://github.com/resin-io/etcher/issues/836
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>