### PR TITLE
Remove `rindle` from `devDependencies` in `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "jsdoc-to-markdown": "^1.1.1",
     "mocha": "^2.4.5",
     "mochainon": "^1.0.0",
-    "rindle": "^1.3.0",
     "tmp": "0.0.28"
   },
   "dependencies": {


### PR DESCRIPTION
This dependency is also duplicated in `dependencies`. Since we use it on
the final code, it should not be present in `devDependencies` at all.

Fixes: https://github.com/resin-io-modules/etcher-image-stream/issues/43
Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>